### PR TITLE
Goodbye, ts-loader

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,8 +1,14 @@
 module.exports = (baseConfig, env, config) => {
+  // refs: https://storybook.js.org/configurations/typescript-config/
   config.module.rules.push({
     test: /\.tsx?$/,
     exclude: /node_modules/,
-    use: [{ loader: require.resolve("ts-loader") }]
+    use: [{
+      loader: require.resolve("babel-loader"),
+      options: {
+        presets: [['react-app', { flow: false, typescript: true }]],
+      }
+    }],
   });
   // react-native を import している箇所を react-native-web に変換
   config.resolve.alias["react-native$"] = require.resolve("react-native-web");

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "react-test-renderer": "^16.5.1",
     "redux-logger": "^3.0.6",
     "scaffdog": "^0.0.7",
-    "ts-loader": "^5.3.3",
     "typescript": "^3.3.3",
     "typescript-eslint-parser": "^22.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5238,7 +5238,7 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-enhanced-resolve@^4.0.0, enhanced-resolve@^4.1.0:
+enhanced-resolve@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz#41c7e0bfdfe74ac1ffe1e57ad6a5c6c9f3742a7f"
   integrity sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==
@@ -12074,7 +12074,7 @@ scoped-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/scoped-regex/-/scoped-regex-1.0.0.tgz#a346bb1acd4207ae70bd7c0c7ca9e566b6baddb8"
   integrity sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.1, semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
@@ -13113,17 +13113,6 @@ trough@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.3.tgz#e29bd1614c6458d44869fc28b255ab7857ef7c24"
   integrity sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==
-
-ts-loader@^5.3.3:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-5.3.3.tgz#8b4af042e773132d86b3c99ef0acf3b4d325f473"
-  integrity sha512-KwF1SplmOJepnoZ4eRIloH/zXL195F51skt7reEsS6jvDqzgc/YSbz9b8E07GxIUwLXdcD4ssrJu6v8CwaTafA==
-  dependencies:
-    chalk "^2.3.0"
-    enhanced-resolve "^4.0.0"
-    loader-utils "^1.0.2"
-    micromatch "^3.1.4"
-    semver "^5.0.1"
 
 tslib@1.9.0:
   version "1.9.0"


### PR DESCRIPTION
> ちょっと試してみますね
> https://twitter.com/Nkzn/status/1098547329576067072

試してみました。[公式ドキュメント](https://storybook.js.org/configurations/typescript-config/)を参考に、babel-loader版の実装にしてあります。

`@babel/preset-typescript` を入れずに済んだのが意外でしたが、yarn.lockを見たところ、どうやら `@storybook/react > babel-preset-react-app > @babel/preset-typescript` の順で、dependencyが繋がっていたようです。